### PR TITLE
fix: add min-w to prevent potential layout issues

### DIFF
--- a/packages/ui/src/components/DetailsView/DetailsView.tsx
+++ b/packages/ui/src/components/DetailsView/DetailsView.tsx
@@ -1,6 +1,7 @@
 import type { TraceSpan } from "@evilmartians/agent-prism-types";
 import type { ReactElement } from "react";
 
+import cn from "classnames";
 import { SquareTerminal, Tags, ArrowRightLeft } from "lucide-react";
 
 import type { AvatarProps } from "../Avatar";
@@ -85,7 +86,10 @@ export const DetailsView = ({
 
   return (
     <div
-      className={`rounded border border-gray-200 bg-white p-4 dark:border-gray-600 dark:bg-gray-950 ${className}`}
+      className={cn(
+        "min-w-0 rounded border border-gray-200 bg-white p-4 dark:border-gray-600 dark:bg-gray-950",
+        className
+      )}
     >
       <DetailsViewHeader data={data} avatar={avatar} copyButton={copyButton} />
 

--- a/packages/ui/src/components/TraceList/TraceList.tsx
+++ b/packages/ui/src/components/TraceList/TraceList.tsx
@@ -27,7 +27,7 @@ export const TraceList = ({
   return (
     <div
       className={cn(
-        "w-full",
+        "w-full min-w-0",
         "flex flex-col gap-3",
         expanded ? "w-full" : "w-fit",
         className,

--- a/packages/ui/src/components/TreeView.tsx
+++ b/packages/ui/src/components/TreeView.tsx
@@ -30,7 +30,7 @@ export const TreeView: FC<TreeViewProps> = ({
   const { minStart, maxEnd } = findTimeRange(allCards);
 
   return (
-    <div className="w-full p-2 pt-4">
+    <div className="w-full p-2 pt-4 min-w-0">
       <ul
         className={cn(className, "overflow-x-auto")}
         role="tree"


### PR DESCRIPTION
Found an issue while recording demo - content was expanding beyond the screen dew to some very long values in JSON/text in DetailsView