### PR TITLE
Add versions to dependencies in readme install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ npm install @evilmartians/agent-prism-data @evilmartians/agent-prism-types
 Install required UI dependencies:
 
 ```bash
-npm install @radix-ui/react-collapsible @radix-ui/react-tabs classnames lucide-react react-json-pretty react-resizable-panels
+npm install @radix-ui/react-collapsible@1 @radix-ui/react-tabs@1 classnames@2 lucide-react@0 react-json-pretty@2 react-resizable-panels@3
 ```
 
 ## Quick Start


### PR DESCRIPTION
This PR adds versions to the dependencies in the install instructions of the README.

## Motivation

Because we distribute with degit (copying components’ src to the consuming project), the dependencies are installed as a separate step and aren’t locked to any version. So, when you follow the install instructions, latest versions are installed, and **they can have some breaking changes since when the readme was written**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation instructions updated with pinned major versions for UI dependencies and utility packages, ensuring consistent and reproducible development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->