### PR TITLE
Add image extraction and Images tab to DetailsView

### DIFF
--- a/packages/data/src/common/extract-image-paths.test.ts
+++ b/packages/data/src/common/extract-image-paths.test.ts
@@ -1,0 +1,124 @@
+import type {
+  TraceSpan,
+  TraceSpanAttribute,
+} from "@evilmartians/agent-prism-types";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  extractAttributeImages,
+  extractImagePaths,
+  isImageSource,
+  spanHasImages,
+} from "./extract-image-paths";
+
+const baseSpan = (overrides: Partial<TraceSpan> = {}): TraceSpan => ({
+  id: "span-1",
+  title: "Span",
+  startTime: new Date("2024-01-01T00:00:00Z"),
+  endTime: new Date("2024-01-01T00:00:01Z"),
+  duration: 1000,
+  type: "llm_call",
+  raw: "{}",
+  status: "success",
+  ...overrides,
+});
+
+describe("isImageSource", () => {
+  it("recognizes data URIs and image extensions, rejects others", () => {
+    expect(isImageSource("data:image/png;base64,AAAA")).toBe(true);
+    expect(isImageSource("/tmp/shot.png")).toBe(true);
+    expect(isImageSource("/tmp/SHOT.JPEG")).toBe(true); // case-insensitive
+    expect(isImageSource("just text")).toBe(false);
+    expect(isImageSource("")).toBe(false);
+  });
+});
+
+describe("extractImagePaths", () => {
+  it("builds a base64 data URL from an image content block", () => {
+    const content = JSON.stringify([
+      { type: "image", source: { media_type: "image/png", data: "AAAA" } },
+    ]);
+
+    expect(extractImagePaths(content)).toEqual(["data:image/png;base64,AAAA"]);
+  });
+
+  it("defaults the media type to image/png", () => {
+    const content = JSON.stringify([
+      { type: "image", source: { data: "BBBB" } },
+    ]);
+
+    expect(extractImagePaths(content)).toEqual(["data:image/png;base64,BBBB"]);
+  });
+
+  it("finds file paths via regex and dedups", () => {
+    const out = extractImagePaths("see /a/x.png and /a/x.png and /b/y.jpg");
+
+    expect([...out].sort()).toEqual(["/a/x.png", "/b/y.jpg"]);
+  });
+
+  it("returns [] for content with no images", () => {
+    expect(extractImagePaths("no images here")).toEqual([]);
+    expect(extractImagePaths("")).toEqual([]);
+  });
+});
+
+describe("extractAttributeImages", () => {
+  it("parses the claude_code.images attribute array", () => {
+    const attributes: TraceSpanAttribute[] = [
+      {
+        key: "gen_ai.request.model",
+        value: { stringValue: "claude-opus-4-6" },
+      },
+      {
+        key: "claude_code.images",
+        value: { stringValue: JSON.stringify(["data:image/png;base64,AAAA"]) },
+      },
+    ];
+
+    expect(extractAttributeImages(attributes)).toEqual([
+      "data:image/png;base64,AAAA",
+    ]);
+  });
+
+  it("returns [] when the attribute is absent or malformed", () => {
+    expect(extractAttributeImages(undefined)).toEqual([]);
+    expect(extractAttributeImages([])).toEqual([]);
+    expect(
+      extractAttributeImages([
+        { key: "claude_code.images", value: { stringValue: "not-json" } },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("spanHasImages", () => {
+  it("is true when the input carries an image path", () => {
+    expect(spanHasImages(baseSpan({ input: "see /a/x.png" }))).toBe(true);
+  });
+
+  it("is true when the output carries an image path", () => {
+    expect(spanHasImages(baseSpan({ output: "result /b/y.jpg" }))).toBe(true);
+  });
+
+  it("is true when the claude_code.images attribute is present", () => {
+    const span = baseSpan({
+      attributes: [
+        {
+          key: "claude_code.images",
+          value: {
+            stringValue: JSON.stringify(["data:image/png;base64,AAAA"]),
+          },
+        },
+      ],
+    });
+
+    expect(spanHasImages(span)).toBe(true);
+  });
+
+  it("is false when the span has no images", () => {
+    expect(
+      spanHasImages(baseSpan({ input: "plain text", output: "done" })),
+    ).toBe(false);
+  });
+});

--- a/packages/data/src/common/extract-image-paths.ts
+++ b/packages/data/src/common/extract-image-paths.ts
@@ -1,0 +1,191 @@
+import type {
+  TraceSpan,
+  TraceSpanAttribute,
+} from "@evilmartians/agent-prism-types";
+
+const IMAGE_EXTENSIONS = [
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".svg",
+  ".bmp",
+];
+
+export function isImageSource(str: string): boolean {
+  if (!str || typeof str !== "string") return false;
+
+  const trimmed = str.trim();
+
+  if (trimmed.startsWith("data:image/")) return true;
+
+  const lowerStr = trimmed.toLowerCase();
+
+  return IMAGE_EXTENSIONS.some((ext) => lowerStr.endsWith(ext));
+}
+
+interface ImageContentBlock {
+  type: "image";
+  source: {
+    type?: string;
+    media_type?: string;
+    data: string;
+  };
+}
+
+function isImageContentBlock(obj: unknown): obj is ImageContentBlock {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    (obj as { type: unknown }).type === "image" &&
+    "source" in obj &&
+    typeof (obj as { source: unknown }).source === "object" &&
+    (obj as { source: { data: unknown } }).source !== null &&
+    "data" in (obj as { source: object }).source
+  );
+}
+
+function extractImagesFromContentBlocks(content: unknown): string[] {
+  const images: string[] = [];
+
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (isImageContentBlock(block)) {
+        const mediaType = block.source.media_type || "image/png";
+        const dataUrl = `data:${mediaType};base64,${block.source.data}`;
+
+        images.push(dataUrl);
+      }
+
+      if (typeof block === "object" && block !== null && "content" in block) {
+        images.push(
+          ...extractImagesFromContentBlocks(
+            (block as { content: unknown }).content,
+          ),
+        );
+      }
+    }
+  }
+
+  return images;
+}
+
+export function extractImagePaths(content: string): string[] {
+  if (!content || typeof content !== "string") return [];
+
+  const images: string[] = [];
+
+  try {
+    const parsed: unknown = JSON.parse(content);
+
+    images.push(...extractImagesFromContentBlocks(parsed));
+
+    if (typeof parsed === "object" && parsed !== null && "content" in parsed) {
+      images.push(
+        ...extractImagesFromContentBlocks(
+          (parsed as { content: unknown }).content,
+        ),
+      );
+    }
+  } catch {
+    const startPattern = '[{"type":"image"';
+    let startIdx = content.indexOf(startPattern);
+
+    while (startIdx !== -1) {
+      let bracketCount = 0;
+      let endIdx = startIdx;
+
+      for (let i = startIdx; i < content.length; i++) {
+        if (content[i] === "[") bracketCount++;
+        else if (content[i] === "]") {
+          bracketCount--;
+
+          if (bracketCount === 0) {
+            endIdx = i + 1;
+            break;
+          }
+        }
+      }
+
+      if (endIdx > startIdx) {
+        try {
+          const jsonStr = content.slice(startIdx, endIdx);
+          const parsed: unknown = JSON.parse(jsonStr);
+
+          images.push(...extractImagesFromContentBlocks(parsed));
+        } catch {
+          // not valid JSON, skip this match
+        }
+      }
+
+      startIdx = content.indexOf(startPattern, startIdx + 1);
+    }
+  }
+
+  const pathRegex =
+    /(?:^|[\s"'`])([/\w\-._]+\.(?:png|jpg|jpeg|gif|webp|svg|bmp))(?:[\s"'`]|$)/gi;
+
+  for (const match of content.matchAll(pathRegex)) {
+    if (match[1]) {
+      images.push(match[1]);
+    }
+  }
+
+  const base64Regex = /(data:image\/[^;]+;base64,[a-zA-Z0-9+/]+=*)/g;
+
+  for (const match of content.matchAll(base64Regex)) {
+    if (match[1]) {
+      images.push(match[1]);
+    }
+  }
+
+  return [...new Set(images)];
+}
+
+/**
+ * Image data-URLs carried on the `claude_code.images` span attribute (a JSON array
+ * of `data:<mime>;base64,...` strings emitted by the Claude Code transcoder). This is
+ * the typed-image-field path — distinct from `extractImagePaths`, which scrapes images
+ * out of the free-text input/output. Returns [] when the attribute is absent or malformed.
+ */
+export function extractAttributeImages(
+  attributes: readonly TraceSpanAttribute[] | undefined,
+): string[] {
+  if (!attributes) return [];
+
+  const raw = attributes.find((attr) => attr.key === "claude_code.images")
+    ?.value?.stringValue;
+
+  if (!raw) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+
+    return Array.isArray(parsed)
+      ? parsed.filter((url): url is string => typeof url === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Whether a span exposes any images — scraped from its input/output free text or
+ * carried on the `claude_code.images` attribute. Mirrors the extraction done by
+ * `DetailsViewImagesTab`, so the Images tab is shown only when it would have content.
+ */
+export function spanHasImages(span: TraceSpan): boolean {
+  if (span.input && extractImagePaths(String(span.input)).length > 0) {
+    return true;
+  }
+
+  if (extractAttributeImages(span.attributes).length > 0) {
+    return true;
+  }
+
+  return (
+    Boolean(span.output) && extractImagePaths(String(span.output)).length > 0
+  );
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -4,6 +4,12 @@ export { getTimelineData } from "./common/get-timeline-data.js";
 export { flattenSpans } from "./common/flatten-spans.js";
 export { findTimeRange } from "./common/find-time-range.js";
 export { filterSpansRecursively } from "./common/filter-spans-recursively.js";
+export {
+  isImageSource,
+  extractImagePaths,
+  extractAttributeImages,
+  spanHasImages,
+} from "./common/extract-image-paths.js";
 
 export { openTelemetrySpanAdapter } from "./open-telemetry/adapter.js";
 export { langfuseSpanAdapter } from "./langfuse/adapter.js";

--- a/packages/storybook/src/stories/DetailsView.stories.tsx
+++ b/packages/storybook/src/stories/DetailsView.stories.tsx
@@ -121,3 +121,16 @@ export const CopyButton: Story = {
     },
   },
 };
+
+// The "Images" tab only appears when the span exposes images (here, image paths
+// referenced in the input/output). Spans without images never show the tab.
+export const WithImages: Story = {
+  args: {
+    data: {
+      ...mockSpanData,
+      input: "Analyze the screenshot at /uploads/screenshot.png",
+      output: "Annotated result saved to /results/annotated.png",
+    },
+    defaultTab: "images",
+  },
+};

--- a/packages/storybook/src/stories/DetailsViewImagesTab.stories.tsx
+++ b/packages/storybook/src/stories/DetailsViewImagesTab.stories.tsx
@@ -1,0 +1,88 @@
+import type { TraceSpan } from "@evilmartians/agent-prism-types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  DetailsViewImagesTab,
+  DetailsViewImagesTabSource,
+} from "@evilmartians/agent-prism-ui";
+import {
+  Description,
+  Primary,
+  Controls,
+  Stories,
+  Source,
+} from "@storybook/blocks";
+
+// A 1x1 transparent PNG — renders as a real (tiny) image in the gallery.
+const PIXEL_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+const baseSpan = (overrides: Partial<TraceSpan>): TraceSpan => ({
+  id: "span-images-001",
+  title: "Image-bearing span",
+  startTime: new Date("2024-01-15T10:30:00Z"),
+  endTime: new Date("2024-01-15T10:30:03Z"),
+  duration: 3000,
+  type: "tool_execution",
+  raw: "{}",
+  status: "success",
+  ...overrides,
+});
+
+const meta = {
+  title: "Main Components/DetailsViewImagesTab",
+  component: DetailsViewImagesTab,
+  parameters: {
+    layout: "centered",
+    docs: {
+      page: () => (
+        <>
+          <Description />
+          <Primary />
+          <Controls />
+          <Stories />
+          <Source code={DetailsViewImagesTabSource} language="tsx" />
+        </>
+      ),
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    data: {
+      description:
+        "The span whose input/output/attributes are scanned for images",
+    },
+  },
+} satisfies Meta<typeof DetailsViewImagesTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InputAndOutputImages: Story = {
+  args: {
+    data: baseSpan({
+      input:
+        "Please analyze the screenshot at /uploads/screenshot.png and /uploads/diagram.jpg",
+      output: "Generated chart saved to /results/chart.png",
+    }),
+  },
+};
+
+export const AttributeImages: Story = {
+  args: {
+    data: baseSpan({
+      attributes: [
+        {
+          key: "claude_code.images",
+          value: { stringValue: JSON.stringify([PIXEL_PNG]) },
+        },
+      ],
+    }),
+  },
+};
+
+export const NoImages: Story = {
+  args: {
+    data: baseSpan({ input: "plain text prompt", output: "plain text answer" }),
+  },
+};

--- a/packages/ui/src/components/DetailsView/DetailsView.tsx
+++ b/packages/ui/src/components/DetailsView/DetailsView.tsx
@@ -1,9 +1,15 @@
 import type { TraceSpan } from "@evilmartians/agent-prism-types";
 import type { ReactElement, ReactNode } from "react";
 
+import { spanHasImages } from "@evilmartians/agent-prism-data";
 import cn from "classnames";
-import { SquareTerminal, Tags, ArrowRightLeft } from "lucide-react";
-import { useState } from "react";
+import {
+  SquareTerminal,
+  Tags,
+  ArrowRightLeft,
+  Image as ImageIcon,
+} from "lucide-react";
+import { useMemo, useState } from "react";
 
 import type { AvatarProps } from "../Avatar";
 import type { TabItem } from "../Tabs";
@@ -11,10 +17,11 @@ import type { TabItem } from "../Tabs";
 import { TabSelector } from "../TabSelector";
 import { DetailsViewAttributesTab } from "./DetailsViewAttributesTab";
 import { DetailsViewHeader } from "./DetailsViewHeader";
+import { DetailsViewImagesTab } from "./DetailsViewImagesTab";
 import { DetailsViewInputOutputTab } from "./DetailsViewInputOutputTab";
 import { DetailsViewRawDataTab } from "./DetailsViewRawDataTab";
 
-type DetailsViewTab = "input-output" | "attributes" | "raw";
+type DetailsViewTab = "input-output" | "attributes" | "raw" | "images";
 
 export interface DetailsViewProps {
   /**
@@ -80,6 +87,12 @@ const TAB_ITEMS: TabItem<DetailsViewTab>[] = [
   },
 ];
 
+const IMAGES_TAB_ITEM: TabItem<DetailsViewTab> = {
+  value: "images",
+  label: "Images",
+  icon: <ImageIcon className="size-4" />,
+};
+
 export const DetailsView = ({
   data,
   avatar,
@@ -91,6 +104,11 @@ export const DetailsView = ({
   onTabChange,
 }: DetailsViewProps): ReactElement => {
   const [tab, setTab] = useState<DetailsViewTab>(defaultTab);
+
+  const tabItems = useMemo(
+    () => (spanHasImages(data) ? [...TAB_ITEMS, IMAGES_TAB_ITEM] : TAB_ITEMS),
+    [data],
+  );
 
   const handleTabChange = (tabValue: DetailsViewTab) => {
     setTab(tabValue);
@@ -125,7 +143,7 @@ export const DetailsView = ({
       <div className="mb-4 shrink-0">{headerContent}</div>
       <div className="shrink-0">
         <TabSelector
-          items={TAB_ITEMS}
+          items={tabItems}
           value={tab}
           onValueChange={handleTabChange}
           theme="underline"
@@ -137,6 +155,7 @@ export const DetailsView = ({
         {tab === "input-output" && <DetailsViewInputOutputTab data={data} />}
         {tab === "attributes" && <DetailsViewAttributesTab data={data} />}
         {tab === "raw" && <DetailsViewRawDataTab data={data} />}
+        {tab === "images" && <DetailsViewImagesTab data={data} />}
       </div>
     </div>
   );

--- a/packages/ui/src/components/DetailsView/DetailsViewImagesTab.tsx
+++ b/packages/ui/src/components/DetailsView/DetailsViewImagesTab.tsx
@@ -1,0 +1,113 @@
+import type { TraceSpan } from "@evilmartians/agent-prism-types";
+import type { ReactElement } from "react";
+
+import {
+  extractAttributeImages,
+  extractImagePaths,
+} from "@evilmartians/agent-prism-data";
+import { useMemo } from "react";
+
+import { ImageGallery } from "../ImageViewer";
+
+interface DetailsViewImagesTabProps {
+  data: TraceSpan;
+}
+
+export function DetailsViewImagesTab({
+  data,
+}: DetailsViewImagesTabProps): ReactElement {
+  const { inputImages, outputImages, allImages } = useMemo(() => {
+    const inputPaths = [
+      ...(data.input ? extractImagePaths(String(data.input)) : []),
+      ...extractAttributeImages(data.attributes),
+    ];
+    const outputPaths = data.output
+      ? extractImagePaths(String(data.output))
+      : [];
+
+    const buildEntries = (paths: string[], label: "Input" | "Output") =>
+      paths.map((src) => ({
+        src,
+        caption: `${label}: ${src.split("/").pop() || src}`,
+      }));
+
+    const input = buildEntries(inputPaths, "Input");
+    const output = buildEntries(outputPaths, "Output");
+
+    return {
+      inputImages: input,
+      outputImages: output,
+      allImages: [...input, ...output],
+    };
+  }, [data.input, data.output, data.attributes]);
+
+  if (allImages.length === 0) {
+    return (
+      <div className="border-agentprism-border bg-agentprism-muted rounded-md border p-8 text-center">
+        <p className="text-agentprism-muted-foreground text-sm">
+          No images found in this span&rsquo;s input or output.
+        </p>
+      </div>
+    );
+  }
+
+  const hasInputImages = inputImages.length > 0;
+  const hasOutputImages = outputImages.length > 0;
+  const showSeparateSections = hasInputImages && hasOutputImages;
+
+  return (
+    <div className="space-y-6">
+      <div className="text-agentprism-muted-foreground flex items-center gap-2 text-sm">
+        <span className="text-agentprism-foreground font-medium">
+          {allImages.length} image{allImages.length > 1 ? "s" : ""} found
+        </span>
+        {showSeparateSections && (
+          <span>
+            ({inputImages.length} in input, {outputImages.length} in output)
+          </span>
+        )}
+      </div>
+
+      {showSeparateSections ? (
+        <>
+          {hasInputImages && (
+            <div>
+              <h4 className="text-agentprism-foreground mb-3 text-sm font-medium">
+                Input Images ({inputImages.length})
+              </h4>
+              <ImageGallery images={inputImages} />
+            </div>
+          )}
+
+          {hasOutputImages && (
+            <div>
+              <h4 className="text-agentprism-foreground mb-3 text-sm font-medium">
+                Output Images ({outputImages.length})
+              </h4>
+              <ImageGallery images={outputImages} />
+            </div>
+          )}
+        </>
+      ) : (
+        <ImageGallery images={allImages} />
+      )}
+
+      <div className="border-agentprism-border bg-agentprism-muted rounded-md border p-3">
+        <h4 className="text-agentprism-muted-foreground mb-2 text-xs font-medium">
+          Image Paths
+        </h4>
+        <div className="space-y-1">
+          {allImages.map((image, idx) => (
+            <div
+              key={`${image.src}-${idx}`}
+              className="text-agentprism-foreground truncate font-mono text-xs"
+              title={image.src}
+            >
+              {image.src}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/ImageBadge.tsx
+++ b/packages/ui/src/components/ImageBadge.tsx
@@ -1,0 +1,34 @@
+import type { ComponentPropsWithRef, ReactElement } from "react";
+
+import cn from "classnames";
+import { Image } from "lucide-react";
+
+import { Badge, type BadgeProps } from "./Badge";
+
+export type ImageBadgeProps = ComponentPropsWithRef<"span"> & {
+  count?: number;
+  size?: BadgeProps["size"];
+};
+
+export const ImageBadge = ({
+  count,
+  size,
+  className,
+  ...rest
+}: ImageBadgeProps): ReactElement => {
+  const label = count && count > 1 ? `${count} Images` : "Image";
+
+  return (
+    <Badge
+      unstyled
+      iconStart={<Image className="size-3" />}
+      size={size}
+      {...rest}
+      label={label}
+      className={cn(
+        "bg-agentprism-badge-tool text-agentprism-badge-tool-foreground",
+        className,
+      )}
+    />
+  );
+};

--- a/packages/ui/src/components/ImageViewer.tsx
+++ b/packages/ui/src/components/ImageViewer.tsx
@@ -1,0 +1,250 @@
+import { useState, useCallback, useEffect, type ReactElement } from "react";
+
+export interface ImageViewerProps {
+  src: string;
+  alt?: string;
+  caption?: string;
+  className?: string;
+  expandable?: boolean;
+}
+
+export interface ImageGalleryProps {
+  images: Array<{
+    src: string;
+    alt?: string;
+    caption?: string;
+  }>;
+  className?: string;
+}
+
+function getImageUrl(src: string): string {
+  if (src.startsWith("data:") || src.startsWith("http")) {
+    return src;
+  }
+
+  if (src.startsWith("/")) {
+    return src;
+  }
+
+  return src;
+}
+
+interface ImageModalProps {
+  src: string;
+  alt?: string;
+  caption?: string;
+  onClose: () => void;
+}
+
+function ImageModal({
+  src,
+  alt,
+  caption,
+  onClose,
+}: ImageModalProps): ReactElement {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+
+    window.addEventListener("keydown", handleEscape);
+
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image preview"
+    >
+      <div
+        className="relative max-h-[90vh] max-w-[90vw]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="bg-agentprism-background text-agentprism-foreground hover:bg-agentprism-secondary absolute -right-2 -top-2 flex size-8 items-center justify-center rounded-full shadow-lg"
+          aria-label="Close image preview"
+        >
+          <svg
+            className="size-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+
+        <img
+          src={getImageUrl(src)}
+          alt={alt || "Preview"}
+          className="max-h-[85vh] max-w-full rounded-lg object-contain"
+        />
+
+        {caption && (
+          <div className="mt-2 text-center text-sm text-white/80">
+            {caption}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ImageViewer({
+  src,
+  alt,
+  caption,
+  className = "",
+  expandable = true,
+}: ImageViewerProps): ReactElement {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const handleClick = useCallback(() => {
+    if (expandable && !hasError) {
+      setIsExpanded(true);
+    }
+  }, [expandable, hasError]);
+
+  const handleClose = useCallback(() => {
+    setIsExpanded(false);
+  }, []);
+
+  const handleLoad = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
+  const handleError = useCallback(() => {
+    setIsLoading(false);
+    setHasError(true);
+  }, []);
+
+  if (hasError) {
+    return (
+      <div
+        className={`border-agentprism-border bg-agentprism-muted rounded-lg border p-4 ${className}`}
+      >
+        <div className="text-agentprism-muted-foreground flex items-center gap-2 text-sm">
+          <svg
+            className="size-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          <span>Failed to load image</span>
+        </div>
+        <div className="text-agentprism-muted-foreground mt-1 truncate text-xs">
+          {src}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={`border-agentprism-border bg-agentprism-muted group relative overflow-hidden rounded-lg border ${expandable ? "cursor-pointer" : ""} ${className}`}
+        onClick={handleClick}
+        role={expandable ? "button" : undefined}
+        tabIndex={expandable ? 0 : undefined}
+        onKeyDown={
+          expandable ? (e) => e.key === "Enter" && handleClick() : undefined
+        }
+      >
+        {isLoading && (
+          <div className="bg-agentprism-muted absolute inset-0 flex items-center justify-center">
+            <div className="border-agentprism-border border-t-agentprism-brand size-6 animate-spin rounded-full border-2" />
+          </div>
+        )}
+
+        <img
+          src={getImageUrl(src)}
+          alt={alt || "Image preview"}
+          className={`max-h-64 w-full object-contain transition-opacity ${isLoading ? "opacity-0" : "opacity-100"}`}
+          onLoad={handleLoad}
+          onError={handleError}
+        />
+
+        {expandable && !isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all group-hover:bg-black/30 group-hover:opacity-100">
+            <div className="rounded-full bg-white/90 p-2">
+              <svg
+                className="size-5 text-gray-800"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"
+                />
+              </svg>
+            </div>
+          </div>
+        )}
+
+        {caption && (
+          <div className="border-agentprism-border bg-agentprism-background text-agentprism-muted-foreground border-t px-3 py-2 text-xs">
+            {caption}
+          </div>
+        )}
+      </div>
+
+      {isExpanded && (
+        <ImageModal
+          src={src}
+          alt={alt}
+          caption={caption}
+          onClose={handleClose}
+        />
+      )}
+    </>
+  );
+}
+
+export function ImageGallery({
+  images,
+  className = "",
+}: ImageGalleryProps): ReactElement {
+  if (images.length === 0) {
+    return (
+      <div className="text-agentprism-muted-foreground text-sm">
+        No images found
+      </div>
+    );
+  }
+
+  if (images.length === 1) {
+    return <ImageViewer {...images[0]} className={className} />;
+  }
+
+  return (
+    <div
+      className={`grid gap-3 ${images.length === 2 ? "grid-cols-2" : "grid-cols-2 md:grid-cols-3"} ${className}`}
+    >
+      {images.map((image, index) => (
+        <ImageViewer key={`${image.src}-${index}`} {...image} />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -34,6 +34,17 @@ export { default as SpanBadgeSource } from "./components/SpanBadge.tsx?raw";
 export { TokensBadge } from "./components/TokensBadge";
 export { default as TokensBadgeSource } from "./components/TokensBadge.tsx?raw";
 
+export { ImageBadge, type ImageBadgeProps } from "./components/ImageBadge";
+export { default as ImageBadgeSource } from "./components/ImageBadge.tsx?raw";
+
+export {
+  ImageViewer,
+  ImageGallery,
+  type ImageViewerProps,
+  type ImageGalleryProps,
+} from "./components/ImageViewer";
+export { default as ImageViewerSource } from "./components/ImageViewer.tsx?raw";
+
 export {
   SpanCard,
   type SpanCardViewOptions,
@@ -51,6 +62,9 @@ export { default as TraceListSource } from "./components/TraceList/TraceList.tsx
 
 export { DetailsView } from "./components/DetailsView/DetailsView";
 export { default as DetailsViewSource } from "./components/DetailsView/DetailsView.tsx?raw";
+
+export { DetailsViewImagesTab } from "./components/DetailsView/DetailsViewImagesTab";
+export { default as DetailsViewImagesTabSource } from "./components/DetailsView/DetailsViewImagesTab.tsx?raw";
 
 export { Tabs } from "./components/Tabs";
 export { default as TabsSource } from "./components/Tabs.tsx?raw";


### PR DESCRIPTION
## Summary

Adds end-to-end image support to the trace viewer: pure image-detection helpers in `@evilmartians/agent-prism-data`, an `Images` tab in `DetailsView` that surfaces images found in a span, plus the supporting `ImageBadge` and `ImageViewer`/`ImageGallery` components. The tab is shown **only when the span actually exposes images**, and stays hidden otherwise.

Ported from the internal `agent-prism-saas` repo (PR 3 of the open-source port backlog).

## What's included

### `packages/data` — pure, unit-tested helpers
New `src/common/extract-image-paths.ts`:

- `isImageSource` — recognizes data URIs and image file extensions (case-insensitive)
- `extractImagePaths` — pulls images out of fbase64 data URLs from Anthropic-style `image`content blocks (defaults media type to `image/png`), file paths via regex, and inline `data:image/...;base64,...` URLs; deduplicates the result
- `extractAttributeImages` — reads the JSON array carried on the `claude_code.images` span attribute; returns `[]` when absent or malformed
- `spanHasImages` — predicate mirroring the tab's extraction, used to gate tab visibility

Covered by **11 vitest cases**.

### `packages/ui` — components
- `ImageBadge` — badge shown on spans that carry images
- `ImageViewer` / `ImageGallery` — image preview with expand-to-modal, loading and error states
- `DetailsView/DetailsViewImagesTab` — renders input/output image galleries and the raw image-path list
- `DetailsView` — adds the conditional `Images` tab, gated on `spanHasImages(data)`

All three components (and their `?raw` source strings) are exported from the UI barrel.

### `packages/storybook`
- New `DetailsViewImagesTab.stories.tsx` — input/output paths, a real base64 image, and the empty state
- `DetailsView.stories.tsx` — a `WithImages` story demonstrating the gated tab

## Design notes

- Image-detection logic lives in `data` (pure, DOM-free, fast to test) while rendering stays in `ui`. The `spanHasImages` predicate is the seam that lets tab-visibility be decided and tested without React.
- Tab visibility is gated at the **tab level** in `DetailsView` (a pure function of the span), rather than only showing an empty state inside the tab.
- `ImageBadge` uses the repo's `Badge` idiom (`unstyled` + `cn(...)`) so its color classes don't collide with `Badge`'s default background.

## Verification

- `eslint .` — clean (0 errors)
- `prettier --check` — clean
- Full `pnpm build` green: `types → data → ui → storybook → saas`, including **`storybook build`**
- `vitest` — 11/11 new tests pass (368 in `packages/data`)